### PR TITLE
Replace map provider with Leaflet

### DIFF
--- a/public/css/app.css
+++ b/public/css/app.css
@@ -17,7 +17,8 @@ body {
 }
 
 #map {
-    min-height: 454px;
+    min-height: 50em;
+    padding: 0;
 }
 
 #minimap {

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -30,7 +30,7 @@ $('#laivatListBox').change(function() {
         if (!listBox.options[listBox.selectedIndex]) {
             return false;
         } else {
-            focus_ship(listBox.options[listBox.selectedIndex].value);
+            focusShip(listBox.options[listBox.selectedIndex].value);
         }
     } else if (currentTab == '#miehistö') {
         haeMiehisto();

--- a/public/js/mainpage.js
+++ b/public/js/mainpage.js
@@ -4,7 +4,7 @@
 $("#lstShips").change(function() {
     var lstShips = document.getElementById('lstShips');
     if (lstShips.options[lstShips.selectedIndex]) {
-        focus_ship(lstShips.options[lstShips.selectedIndex].value);
+        focusShip(lstShips.options[lstShips.selectedIndex].value);
     }
 });
 

--- a/public/js/shippage.js
+++ b/public/js/shippage.js
@@ -11,7 +11,7 @@ $('[data-toggle="tab"]').click(function(event) {
     if (targetTab == '#kartta') {
         var listBox = document.getElementById('laivatListBox');
         if (listBox.options[listBox.selectedIndex]) {
-            focus_ship(listBox.options[listBox.selectedIndex].value);
+            focusShip(listBox.options[listBox.selectedIndex].value);
         }
     } else if (targetTab == '#rahti') {
         if (!haeRahti()) {
@@ -35,3 +35,4 @@ $('[data-toggle="tab"]').click(function(event) {
         alert('Tabiä "' + $(event.target).attr('href') + '" ei ole implementoitu');
     }
 });
+

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -15,6 +15,7 @@
     <!-- Styles -->
     <link href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-1q8mTJOASx8j1Au+a5WDVnPi2lkFfwwEAa8hDDdjZlpLegxhjVME1fgjWPGmkzs7" crossorigin="anonymous">
     <link href="{{ asset('css/app.css') }}" rel="stylesheet">
+    @hasSection('head') @yield('head') @endif
 </head>
 <body>
     <div id="app">

--- a/resources/views/main.blade.php
+++ b/resources/views/main.blade.php
@@ -1,9 +1,25 @@
 @extends('layouts.app')
 
+@section('head')
+    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.3.3/dist/leaflet.css" integrity="sha512-Rksm5RenBEKSKFjgI3a41vrjkw4EVPlJ3+OiI65vTjIdo9brlAacEuKOiQ5OFh7cOI1bkDwLqdLw3Zg0cRJAAQ==" crossorigin=""/>
+@endsection()
+
 @section('scripts')
-    <script async defer src="https://maps.googleapis.com/maps/api/js?v=3&key=AIzaSyAK8bzrVV9-fH72e3jyXSSjsWkW5bpduok&callback=initMap"></script>
+    <script src="https://unpkg.com/leaflet@1.3.3/dist/leaflet.js" integrity="sha512-tAGcCfR4Sc5ZP5ZoVz0quoZDYX5aCtEm/eu1KhSLj2c9eFrylXZknQYmxUssFaVJKvvc0dJQixhGjG2yXWiV9Q==" crossorigin=""></script>
     <script src="{{ asset('js/map.js') }}"></script>
     <script src="{{ asset('js/mainpage.js') }}"></script>
+    <script>
+        $(document).ready(function() {
+            initMap();
+            @foreach($ships as $ship)
+                @if($ship->latestGps)
+                    addMarker('{{ $ship->ShipName }}', {{ $ship->IMO }}, {{ $ship->latestGps->Lat }}, {{ $ship->latestGps->Lng }}, '{{ $ship->latestGps->UpdatedTime }}');
+                @else
+                    addMarker('{{ $ship->ShipName }}', {{ $ship->IMO }}, 0, 0, 0);
+                @endif
+            @endforeach
+        });
+    </script>
 @endsection
 
 @section('content')
@@ -20,11 +36,7 @@
                     @if ($ships)
                         <select id="lstShips" class="listbox" size="8" name="laivat">
                             @foreach ($ships as $ship)
-                                @if ($ship->latestGps)
-                                    <option value="{{ $ship->IMO }}" data-lat="{{ $ship->latestGps->Lat }}" data-lng="{{ $ship->latestGps->Lng }}" data-updated="{{ $ship->latestGps->UpdatedTime }}">{{ $ship->ShipName }}</option>
-                                @else
-                                    <option value="{{ $ship->IMO }}" data-lat="0" data-lng="0" data-updated="0">{{ $ship->ShipName }}</option>
-                                @endif
+                                <option value="{{ $ship->IMO }}">{{ $ship->ShipName }}</option>
                             @endforeach
                         </select>
                     @else

--- a/resources/views/ship.blade.php
+++ b/resources/views/ship.blade.php
@@ -1,7 +1,11 @@
 @extends('layouts.app')
 
+@section('head')
+    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.3.3/dist/leaflet.css" integrity="sha512-Rksm5RenBEKSKFjgI3a41vrjkw4EVPlJ3+OiI65vTjIdo9brlAacEuKOiQ5OFh7cOI1bkDwLqdLw3Zg0cRJAAQ==" crossorigin=""/>
+@endsection()
+
 @section('scripts')
-    <script async defer src="https://maps.googleapis.com/maps/api/js?v=3&key=AIzaSyAK8bzrVV9-fH72e3jyXSSjsWkW5bpduok&callback=prettyMap"></script>
+    <script src="https://unpkg.com/leaflet@1.3.3/dist/leaflet.js" integrity="sha512-tAGcCfR4Sc5ZP5ZoVz0quoZDYX5aCtEm/eu1KhSLj2c9eFrylXZknQYmxUssFaVJKvvc0dJQixhGjG2yXWiV9Q==" crossorigin=""></script>
     <script src="{{ asset('js/map.js') }}"></script>
 	<script src="{{ asset('js/app.js') }}"></script>
     <script src="{{ asset('js/compass.js') }}"></script>
@@ -13,56 +17,21 @@
             @else
                 compass_init();
             @endif
+
+            initMap('{{ $ship->latestGps->Lat}}', '{{ $ship->latestGps->Lng }}', 9);
+            addMarker('{{ $ship->ShipName }}', {{ $ship->IMO }},
+                      {{ $ship->latestGps->Lat }}, {{ $ship->latestGps->Lng }},
+                      '{{ $ship->latestGps->UpdatedTime }}', false, true);
+            addPolyline([
+                    @for ($i = 0; $i < count($ship->gps); ++$i)
+                        @if ($i + 1 < count($ship->gps))
+                            [ {{ $ship->gps[$i]->Lat }}, {{ $ship->gps[$i]->Lng }} ],
+                        @else
+                            [ {{ $ship->gps[$i]->Lat }}, {{ $ship->gps[$i]->Lng }} ]
+                        @endif
+                    @endfor
+            ]);
         });
-
-        function prettyMap() {
-            let mapOptions = {
-                center: { lat: {{ $ship->latestGps->Lat }}, lng: {{ $ship->latestGps->Lng }} },
-                zoom: 12,
-                streetViewControl: false
-            };
-
-            map = new google.maps.Map(document.getElementById('map'), mapOptions);
-
-            let marker = new google.maps.Marker({
-                position: new google.maps.LatLng({{ $ship->latestGps->Lat }}, {{ $ship->latestGps->Lng }}),
-                map: map,
-                title: '{{ $ship->ShipName }}'
-            });
-
-            let infoWin = new google.maps.InfoWindow({
-                content: '{{ $ship->ShipName }}' + '<br>N: ' +
-                         {{ $ship->latestGps->Lat }} +
-                         '<br>E: ' + {{ $ship->latestGps->Lng }} +
-                         '<br>Update Time: ' + '{{ $ship->latestGps->UpdatedTime }}'
-            });
-
-            google.maps.event.addListener(marker, 'click', function() {
-                infoWin.open(map, marker);
-            });
-
-            let flightPlanCoordinates = [
-                @for ($i = 0; $i < count($ship->gps); ++$i)
-                    @if ($i + 1 < count($ship->gps))
-                        { lat: {{ $ship->gps[$i]->Lat }}, lng: {{ $ship->gps[$i]->Lng }} },
-                    @else
-                        { lat: {{ $ship->gps[$i]->Lat }}, lng: {{ $ship->gps[$i]->Lng }} }
-                    @endif
-                @endfor
-            ];
-
-            let flightPath = new google.maps.Polyline({
-                path: flightPlanCoordinates,
-                geodesic: true,
-                strokeColor: '#FF0000',
-                strokeOpacity: 1.0,
-                strokeWeight: 2
-            });
-
-            flightPath.setMap(map);
-
-            markers.push({ IMO: {{ $ship->IMO }}, Marker: marker, markerInfoWindow: infoWin });
-        }
     </script>
 @endsection
 


### PR DESCRIPTION
@JoriJalkanen review.

Closes #2 by replacing map provider with Leaflet JS library which utilizes OpenStreetMaps.

Also, removed duplicated map related code from Ship information -page template. And `initMap()` now only initializes map.